### PR TITLE
ci: add release workflows for TestPyPI and PyPI

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -1,0 +1,44 @@
+name: Release to TestPyPI
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*.*.*-test"
+
+jobs:
+  test-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction
+
+      - name: Build package
+        run: |
+          poetry build
+
+      - name: Verify build with Twine
+        run: |
+          poetry run twine check dist/*
+
+      - name: Publish to TestPyPI
+        env:
+          POETRY_PYPI_TOKEN_TESTPYPI: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+          poetry config repositories.test-pypi https://test.pypi.org/legacy/
+          poetry publish --no-interaction --repository test-pypi \
+            --username __token__ --password "$POETRY_PYPI_TOKEN_TESTPYPI"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release to PyPi
+
+on:
+  push:
+    tags:
+      - "v*.*.*" # Triggers on semver releases tags
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          poetry install --no-interaction
+
+      - name: Build package
+        run: |
+          poetry build
+
+      - name: Verify build with Twine
+        run: |
+          poetry run twine check dist/*
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          poetry publish --no-interaction --username __token__ --password "$POETRY_PYPI_TOKEN_PYPI"


### PR DESCRIPTION
This PR introduces two new GitHub Actions workflows to automate package publishing:

### ✅ release-test.yml
- Triggers on tags ending in `-test` (e.g. `v0.1.0-test`)
- Builds and verifies the package
- Publishes to [TestPyPI](https://test.pypi.org/)
- Uses `TEST_PYPI_API_TOKEN` secret

### 🚀 release.yml
- Triggers on semver tags (e.g. `v0.1.0`)
- Builds and verifies the package
- Publishes to [PyPI](https://pypi.org/)
- Uses `PYPI_API_TOKEN` secret

These workflows enable safe release testing and straightforward deployment to PyPI.

